### PR TITLE
Correct typos and reflect Python 3 changes

### DIFF
--- a/docs/datastructure.rst
+++ b/docs/datastructure.rst
@@ -4,7 +4,7 @@
 Data Structures
 ===============
 
-Python has a few built-in data structures. If you are wondering what a data structure is, it is nothing but a way to store data and having particular methods to retrieve or manipulate it. We already encountered lists before, now we will go in some depth.
+Python has a few built-in data structures. If you are wondering what a data structure is, it is nothing but a way to store data and having particular methods to retrieve or manipulate it. We already encountered lists before; now we will go in some depth.
 
 .. index:: List
 
@@ -17,7 +17,7 @@ Lists
     >>> a
     [23, 45, 1, -3434, 43624356, 234, 45]
 
-At first we created a list *a*. Then to add *45* at the end of the list we call *a.append(45)* method. You can see that *45* is added at the end of the list. Sometimes it is required to insert data at any place within the list, for that we have *insert()* method.
+At first we created a list *a*. Then to add *45* at the end of the list we call the *a.append(45)* method. You can see that *45* is added at the end of the list. Sometimes it is necessary to insert data at any place within the list, for that we have *insert()* method.
 
 ::
 
@@ -30,14 +30,14 @@ At first we created a list *a*. Then to add *45* at the end of the list we call 
 
 .. index:: count
 
-*count(s)* will return you number of times *s* is in the list. Here we are going to check how many times *45* is there in the list.
+*count(s)* will return you the number of times *s* is in the list. Here we are going to check how many times *45* is there in the list.
 
 ::
 
     >>> a.count(45)
     2
 
-If you want to remove any particular value from the list you have to use *remove()* method.
+If you want to remove any particular value from the list you have to use the *remove()* method.
 
 .. index:: remove
 
@@ -57,7 +57,7 @@ Now to reverse the whole list
     >>> a
     [45, 43624356, -3434, 1, 45, 23, 1, 111]
 
-We can store anything in the list, so first we are going to add another list  *b* in  *a*, then we will learn how to add the values of  *b* into  *a*.
+We can store anything in the list, so first we are going to add another list  *b* in  *a*; then we will learn how to add the values of  *b* into  *a*.
 
 .. index:: extend, append
 
@@ -77,7 +77,7 @@ We can store anything in the list, so first we are going to add another list  *b
 
 .. index:: sort
 
-Above you can see how we used *a.extend()* method to extend the list. To sort any list we have *sort()* method. The *sort()* method will only work if elements in the list are comparable. We will remove the list b from the list and then sort. 
+Above you can see how we used the *a.extend()* method to extend the list. To sort any list we have *sort()* method. The *sort()* method will only work if elements in the list are comparable. We will remove the list b from the list and then sort. 
 
 ::
     >>> a.remove(b)
@@ -98,10 +98,11 @@ You can also delete an element at any particular position of the list using the 
 Using lists as stack and queue
 ==============================
 
-Stacks are often known as LIFO (Last In First Out) structure. It means the data will enter into it at the end , and the last data will come out first. The easiest example can be of couple of marbles in an one side closed pipe. So if you want to take the marbles out of it you have to do that from the end where you inserted the last marble. To achieve the same in code
+Stacks are often known as LIFO (Last In First Out) structure. It means the data will enter into it at the end, and the last data will come out first. The easiest example can be of couple of marbles in an one side closed pipe. So if you want to take the marbles out of it you have to do that from the end where you inserted the last marble. To achieve the same in code
 
 ::
 
+    >>> a = [1, 2, 3, 4, 5, 6]
     >>> a
     [1, 2, 3, 4, 5, 6]
     >>> a.pop()
@@ -120,7 +121,7 @@ Stacks are often known as LIFO (Last In First Out) structure. It means the data 
 
 We learned a new method above *pop()*. *pop(i)* will take out the ith data from the list.
 
-In our daily life we have to encounter queues many times, like in ticket counters or in library or in the billing section of any supermarket. Queue is the data structure where you can append more data at the end and take out data from the beginning. That is why it is known as FIFO (First In First Out).
+In our daily life we have to encounter queues many times, like at ticket counters or in the library or in the billing section of any supermarket. Queue is the data structure where you can append more data at the end and take out data from the beginning. That is why it is known as FIFO (First In First Out).
 
 ::
 
@@ -162,7 +163,7 @@ Above in the second case we used two list comprehensions in a same line.
 Tuples
 ======
 
-Tuples are data separated by comma.
+Tuples are data separated by commas.
 
 ::
 
@@ -176,7 +177,7 @@ Tuples are data separated by comma.
     ...
     Fedora Debian Kubuntu Pardus
 
-You can also unpack values of any tuple in to variables, like
+You can also unpack values of any tuple into variables, like
 
 ::
 
@@ -188,7 +189,7 @@ You can also unpack values of any tuple in to variables, like
     >>> y
     1
 
-Tuples are immutable, that means you can not del/add/edit any value inside the tuple. Here is another example
+Tuples are immutable, meaning that you can not del/add/edit any value inside the tuple. Here is another example
 
 ::
 
@@ -198,7 +199,7 @@ Tuples are immutable, that means you can not del/add/edit any value inside the t
     File "<stdin>", line 1, in <module>
     TypeError: 'tuple' object doesn't support item deletion
 
-As you can see above, Python gives error when we try to delete a value in the tuple.
+As you can see above, Python gives an error when we try to delete a value in the tuple.
 
 To create a tuple which contains only one value, type a trailing comma.
 
@@ -215,7 +216,7 @@ To create a tuple which contains only one value, type a trailing comma.
     >>> type(a)
     <class 'tuple'>
 
-Using the built-in function *type()* you can know the data type of any variable. Remember the *len()* function we used to find the length of any sequence ?
+Using the built-in function *type()* you can know the data type of any variable. Remember the *len()* function we used to find the length of any sequence?
 
 ::
 
@@ -233,7 +234,7 @@ Sets are another type of data structure with no duplicate items. We can apply ma
 
     >>> a = set('abcthabcjwethddda')
     >>> a
-    set(['a', 'c', 'b', 'e', 'd', 'h', 'j', 't', 'w'])
+    {'a', 'c', 'b', 'e', 'd', 'h', 'j', 't', 'w'}
 
 And some examples of the set operations
 
@@ -242,25 +243,25 @@ And some examples of the set operations
     >>> a = set('abracadabra')
     >>> b = set('alacazam')
     >>> a                                  # unique letters in a
-    set(['a', 'r', 'b', 'c', 'd'])
+    {'a', 'r', 'b', 'c', 'd'}
     >>> a - b                              # letters in a but not in b
-    set(['r', 'd', 'b'])
+    {'r', 'd', 'b'}
     >>> a | b                              # letters in either a or b
-    set(['a', 'c', 'r', 'd', 'b', 'm', 'z', 'l'])
+    {'a', 'c', 'r', 'd', 'b', 'm', 'z', 'l'}
     >>> a & b                              # letters in both a and b
-    set(['a', 'c'])
+    {'a', 'c'}
     >>> a ^ b                              # letters in a or b but not both
-    set(['r', 'd', 'b', 'm', 'z', 'l'])
+    {'r', 'd', 'b', 'm', 'z', 'l'}
 
 To add or pop values from a set
 
 ::
 
     >>> a
-    set(['a', 'c', 'b', 'e', 'd', 'h', 'j', 'q', 't', 'w'])
+    {'a', 'c', 'b', 'e', 'd', 'h', 'j', 'q', 't', 'w'}
     >>> a.add('p')
     >>> a
-    set(['a', 'c', 'b', 'e', 'd', 'h', 'j', 'q', 'p', 't', 'w'])
+    {'a', 'c', 'b', 'e', 'd', 'h', 'j', 'q', 'p', 't', 'w'}
 
 .. index:: Dictionary
 
@@ -309,15 +310,15 @@ You must remember that no mutable object can be a *key*, that means you can not 
     >>> dict((('Indian','Delhi'),('Bangladesh','Dhaka')))
     {'Indian': 'Delhi', 'Bangladesh': 'Dhaka'}
 
-.. index:: iteritems
+.. index:: items
 
-If you want to loop through a dict use *iteritems()* method.
+If you want to loop through a dict use *items()* method.
 
 ::
 
     >>> data
     {'Kushal': 'Fedora', 'Jace': 'Mac', 'kart_': 'Debian', 'parthan': 'Ubuntu'}
-    >>> for x, y in data.iteritems():
+    >>> for x, y in data.items():
     ...     print("%s uses %s" % (x, y))
     ...
     Kushal uses Fedora
@@ -392,7 +393,7 @@ In this example , you have to take number of students as input , then ask marks 
         for x in languages:
             marks.append(int(input('Enter marks of %s: ' % x))) #Get the marks for  languages
         data[name] = marks
-    for x, y in data.iteritems():
+    for x, y in data.items():
         total =  sum(y)
         print("%s 's  total marks %d" % (x, total))
         if total < 120:


### PR DESCRIPTION
missing line in stack example code
corrected set examples to use {'f','o'} instead of (['f', 'o'])
Corrected iteritems() to items()
Various minor changes to rephrase in standard English.
